### PR TITLE
feat: ⚙️ add `ignoreFiles` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Now, thanks to this plugin, the LLM version of the website documentation is auto
 - **Description**: Determines whether to generate the `llms.txt` which contains a list of sections with links.
 - **Default**: `true`
 
+#### `ignoreFiles`
+
+- **Description**: An array of strings representing file paths to be ignored.
+- **Default**: `[]`
+
 ## 🚀 Why `vitepress-plugin-llms`?
 
 LLMs (Large Language Models) are great at processing text, but traditional documentation formats can be too heavy and cluttered. `vitepress-plugin-llms` generates raw Markdown documentation that LLMs can efficiently process

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export default function llmstxt(
 	settings: LlmstxtSettings = {
 		generateLLMsFullTxt: true,
 		generateLLMsTxt: true,
+		ignoreFiles: [],
 	},
 ): Plugin {
 	// Store the resolved Vite config
@@ -129,6 +130,11 @@ export default function llmstxt(
 
 			// Copy all markdown files to output directory
 			for (const file of mdFilesList) {
+				if (settings.ignoreFiles?.includes(file)) {
+					log.info(`Ignoring file: ${pc.cyan(file)}`)
+					continue
+				}
+
 				const relativePath = path.relative(process.cwd(), file)
 				const targetPath = path.resolve(outDir, relativePath)
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -13,6 +13,12 @@ export interface LlmstxtSettings {
 	 * @default true
 	 */
 	generateLLMsTxt?: boolean
+	/**
+	 * An array of strings representing file paths to be ignored
+	 *
+	 * @default []
+	 */
+	ignoreFiles?: string[]
 }
 
 /**

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -134,5 +134,28 @@ describe('llmstxt plugin', () => {
 				path.resolve(mockConfig.vitepress.outDir, 'test', 'test.md'),
 			)
 		})
+
+		it('should ignore files specified in ignoreFiles option', () => {
+			plugin = llmstxt({
+				generateLLMsFullTxt: false,
+				generateLLMsTxt: false,
+				ignoreFiles: ['test.md'],
+			})
+			// @ts-ignore
+			plugin.configResolved(mockConfig)
+			// @ts-ignore
+			plugin.transform(0, 'test.md')
+			// @ts-ignore
+			plugin.transform(0, 'test/test.md')
+			// @ts-ignore
+			plugin.generateBundle()
+
+			// Verify that only non-ignored files were written
+			expect(copyFileSync).toHaveBeenCalledTimes(1)
+			expect(copyFileSync).toHaveBeenCalledWith(
+				'test/test.md',
+				path.resolve(mockConfig.vitepress.outDir, 'test', 'test.md'),
+			)
+		})
 	})
 })


### PR DESCRIPTION
Fixes #5

Add `ignoreFiles` option to allow skipping processing of certain documentation files.

* **`src/types.d.ts`**: Add `ignoreFiles` option to `LlmstxtSettings` interface.
* **`src/index.ts`**: Add `ignoreFiles` option to `llmstxt` function parameters. Filter out files specified in `ignoreFiles` option before processing.
* **`README.md`**: Add documentation for `ignoreFiles` option under Plugin Settings section.
* **`tests/index.test.ts`**: Add tests for `ignoreFiles` option in `llmstxt` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/okineadev/vitepress-plugin-llms/issues/5?shareId=XXXX-XXXX-XXXX-XXXX).