### PR TITLE
fix TOC link generation to ensure consistent path formatting across OS

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -28,7 +28,7 @@ export function generateTOC(preparedFiles: PreparedFile[]) {
 
 	for (const file of preparedFiles) {
 		const relativePath = path.relative(process.cwd(), file.path)
-		tableOfContent += `- [${file.title}](/${stripExt(relativePath)}.md)\n`
+		tableOfContent += `- [${file.title}](/${stripExt(relativePath).replace(/\\/g, '/')}.md)\n`
 	}
 
 	return tableOfContent


### PR DESCRIPTION
### Description

There bug and failing tests on windows with slashes because windows uses `\` instead of `/` on unix and markdown should follow second way

```bash
bun test v1.2.6-canary.74 (74768449)

tests\helpers.test.ts:
27 |    },
28 | ]
29 |
30 | describe('generateTOC', () => {
31 |    it('generates a table of contents', () => {
32 |            expect(generateTOC(preparedFilesSample)).toBe(`\
                                                ^
error: expect(received).toBe(expected)

Expected: "- [My Title](/test.md)\n- [My Title 2](/test/test.md)\n"
Received: "- [My Title](/test.md)\n- [My Title 2](/test\\test.md)\n"

      at <anonymous> (Z:\PROJECTS\FORKS\vitepress-plugin-llms\tests\helpers.test.ts:32:44)
✗ generateTOC > generates a table of contents
35 |    })
36 | })
37 |
38 | describe('generateLLMsTxt', () => {
39 |    it('generates a `llms.txt` file', () => {
40 |            expect(generateLLMsTxt(preparedFilesSample)).toMatchSnapshot()
                                                    ^
error: expect(received).toMatchSnapshot(expected)

Expected:
"# LLMs Documentation

This file contains links to all documentation sections.

## Table of Contents

- [My Title](/test.md)
- [My Title 2](/test/test.md)
"

Received:
"# LLMs Documentation

This file contains links to all documentation sections.

## Table of Contents

- [My Title](/test.md)
- [My Title 2](/test\test.md)
"


      at <anonymous> (Z:\PROJECTS\FORKS\vitepress-plugin-llms\tests\helpers.test.ts:40:48)
✗ generateLLMsTxt > generates a `llms.txt` file
```