### PR TITLE
refactor: import `Plugin` from vite

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
-import type { ViteDevServer } from 'vite'
-import type { Plugin } from 'vitepress'
+import type { Plugin, ViteDevServer } from 'vite'
 
 import fs from 'node:fs/promises'
 import path from 'node:path'


### PR DESCRIPTION
`Plugin` of `vitepress` is re-exported from `vite`

### Description
<!-- Describe your changes in detail -->

### Related Issue
<!-- If this PR is related to an issue, please link it here -->

This PR closes #<issue_number>
