### PR TITLE
fix: fix potential undefined reference errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ function llmstxt(userSettings: LlmstxtSettings = {}): Plugin {
 
 		config(config) {
 			const vitepressConfig = config as unknown as VitePressConfig
-			if (vitepressConfig.vitepress.markdown) {
+			if (vitepressConfig?.vitepress?.markdown) {
 				vitepressConfig.vitepress.markdown.config = (md) =>
 					md
 						.use(vitePressPlease('unwrap', 'llm-exclude'))


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->

When checking 'vitepressConfig.vitepress.markdown', an optional chaining operator has been added to avoid potential undefined reference errors.

<img width="959" alt="image" src="https://github.com/user-attachments/assets/3ed80c64-d490-4beb-9c66-a5fe58d8258f" />


### Related Issue
<!-- If this PR is related to an issue, please link it here -->

This PR closes #<issue_number>
