### PR TITLE
Potential fix for code scanning alert no. 10: Useless regular-expression character escape

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,4 +34,4 @@ export const unnecessaryFilesList = {
  * ```
  */
 export const tagRegex = (tagName: RegExp | string, flags?: string) =>
-	new RegExp(`<${tagName}>([\s\S]*?)<\/${tagName}>`, flags)
+	new RegExp(`<${tagName}>([\\s\\S]*?)<\\/${tagName}>`, flags)


### PR DESCRIPTION
Potential fix for [https://github.com/okineadev/vitepress-plugin-llms/security/code-scanning/10](https://github.com/okineadev/vitepress-plugin-llms/security/code-scanning/10)

To fix the issue, the `\s` escape sequence in the string literal should be properly escaped as `\\s`. This ensures that when the string is converted into a regular expression, the `\s` is interpreted as a regular expression escape sequence for whitespace characters. Similarly, the `\/` escape sequence for the forward slash should also be corrected to `\\/` to ensure proper escaping within the string literal.

The corrected line will use double backslashes (`\\`) for all intended escape sequences in the string literal.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
