### PR TITLE
fix: sidebar file path resolving

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -17,7 +17,14 @@ export const splitDirAndFile = (filepath: string) => ({
 })
 
 /**
- * Strips the file extension from a given file path.
+ * Only remove the file extension from the file path if it is a content file.
+ *
+ * This is needed to avoid removing an extension from a file more than once.
+ */
+const contentFileExts = new Set(['.md', '.html', '.vue', '.txt'])
+
+/**
+ * Strips the file extension from a given file path, only if it is a content file.
  *
  * @param filepath - The path to the file.
  * @returns The filename without the extension.
@@ -25,11 +32,16 @@ export const splitDirAndFile = (filepath: string) => ({
 export const stripExt = (filepath: string) => {
 	const { dir, file } = splitDirAndFile(filepath)
 
-	return path.join(dir, path.basename(file, path.extname(file)))
+	const ext = path.extname(file)
+	if (contentFileExts.has(ext)) {
+		return path.join(dir, path.basename(file, ext))
+	}
+
+	return path.join(dir, file)
 }
 
 /**
- * Strips the file extension from a given file path using POSIX format.
+ * Strips the file extension from a given file path using POSIX format, only if it is a content file.
  *
  * @param filepath - The path to the file.
  * @returns The filename without the extension in POSIX format.
@@ -37,7 +49,12 @@ export const stripExt = (filepath: string) => {
 export const stripExtPosix = (filepath: string) => {
 	const { dir, file } = splitDirAndFile(filepath)
 
-	return path.posix.join(dir, path.basename(file, path.extname(file)))
+	const ext = path.extname(file)
+	if (contentFileExts.has(ext)) {
+		return path.posix.join(dir, path.basename(file, ext))
+	}
+
+	return path.posix.join(dir, file)
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,6 +163,13 @@ function llmstxt(userSettings: LlmstxtSettings = {}): [Plugin, Plugin] {
 					return
 				}
 
+				// resolve the sidebar option before reading `mdFiles`
+				// in order to process files from content loaders used in the sidebar function
+				const resolvedSidebar =
+					settings.sidebar instanceof Function
+						? await settings.sidebar(config?.vitepress?.userConfig?.themeConfig?.sidebar)
+						: settings.sidebar
+
 				const outDir = config.vitepress?.outDir ?? 'dist'
 
 				// Create output directory if it doesn't exist
@@ -246,7 +253,7 @@ function llmstxt(userSettings: LlmstxtSettings = {}): [Plugin, Plugin] {
 								templateVariables,
 								vitepressConfig: config?.vitepress?.userConfig,
 								domain: settings.domain,
-								sidebar: settings.sidebar,
+								sidebar: resolvedSidebar,
 								linksExtension: !settings.generateLLMFriendlyDocsForEachPage ? '.html' : undefined,
 								cleanUrls: config.cleanUrls,
 							})

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -238,7 +238,11 @@ export interface LlmstxtSettings extends TemplateVariables {
 	 *
 	 * Usually this parameter is used in rare cases
 	 */
-	sidebar?: DefaultTheme.Sidebar
+	sidebar?:
+		| DefaultTheme.Sidebar
+		| ((
+				configSidebar: DefaultTheme.Sidebar | undefined,
+		  ) => DefaultTheme.Sidebar | undefined | Promise<DefaultTheme.Sidebar | undefined>)
 }
 
 /** Represents a prepared file, including its title and path. */


### PR DESCRIPTION
### Description
This PR improves the resolving of file paths from the sidebar:
* It now also takes into account the `base` parameter in sidebar items, and resolves them like Vitepress does.
* Avoid stripping a file extension more than once by only removing an extension that's part of a defined list.
  I had an issue where `/v3.md` and `/v3.6.md` were both converted to `/v3.md` in `llms.txt` (but not in `llms-full.txt`) - this PR solves that.
* Makes the `sidebar` parameter also accept a function that returns the sidebar, so it can be used to call [`createContentLoader`](https://vitepress.dev/guide/data-loading#createcontentloader) to load build-time data for `vitepress-plugin-llms` to use.

### Related Issue
<!-- If this PR is related to an issue, please link it here -->

This PR renders #36 irrelevant for me, since now the content of `llms.txt` matches the order of the definitions in the sidebar config.

This PR closes #36