### PR TITLE
feat: support `base` URL from VitePress config

### DIFF
--- a/src/generator/llms-full-txt.ts
+++ b/src/generator/llms-full-txt.ts
@@ -13,8 +13,11 @@ export interface GenerateLLMsFullTxtOptions {
 	/** The link extension for generated links. */
 	linksExtension?: LinksExtension
 
-	/** Whether to use clean URLs (without the extension). */
-	cleanUrls?: VitePressConfig['cleanUrls']
+	/** Whether to use clean URLs (without the extension). VitePressConfig['cleanUrls'] */
+	cleanUrls?: boolean
+
+	/** The base URL path from VitePress config. VitePressConfig['base'] */
+	base?: string
 
 	/**
 	 * Optional directory filter to only include files within the specified directory.
@@ -34,7 +37,7 @@ export async function generateLLMsFullTxt(
 	preparedFiles: PreparedFile[],
 	options: GenerateLLMsFullTxtOptions,
 ): Promise<string> {
-	const { domain, linksExtension, cleanUrls, directoryFilter } = options
+	const { domain, linksExtension, cleanUrls, base, directoryFilter } = options
 
 	// Filter files by directory if directoryFilter is provided
 	const filteredFiles = directoryFilter
@@ -54,6 +57,7 @@ export async function generateLLMsFullTxt(
 				filePath: file.path,
 				linksExtension,
 				cleanUrls,
+				base,
 			})
 
 			return matter.stringify(file.file.content, metadata)

--- a/src/generator/llms-full-txt.ts
+++ b/src/generator/llms-full-txt.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import matter from 'gray-matter'
-import type { LinksExtension, LlmstxtSettings, PreparedFile } from '../types'
+import type { LinksExtension, LlmstxtSettings, PreparedFile, VitePressConfig } from '../types'
 import { generateMetadata } from '../utils'
 
 /**
@@ -13,11 +13,14 @@ export interface GenerateLLMsFullTxtOptions {
 	/** The link extension for generated links. */
 	linksExtension?: LinksExtension
 
-	/** Whether to use clean URLs (without the extension). VitePressConfig['cleanUrls'] */
-	cleanUrls?: boolean
+	/** Whether to use clean URLs (without the extension). */
+	cleanUrls?: VitePressConfig['cleanUrls']
 
-	/** The base URL path from VitePress config. VitePressConfig['base'] */
-	base?: string
+	/** The base URL path from VitePress config.
+	 *
+	 * {@link VitePressConfig.base}
+	 */
+	base?: VitePressConfig['base']
 
 	/**
 	 * Optional directory filter to only include files within the specified directory.
@@ -52,7 +55,7 @@ export async function generateLLMsFullTxt(
 	const fileContents = await Promise.all(
 		filteredFiles.map(async (file) => {
 			// file.path is already relative to outDir, so use it directly
-			const metadata = await generateMetadata(file.file, {
+			const metadata = generateMetadata(file.file, {
 				domain,
 				filePath: file.path,
 				linksExtension,

--- a/src/generator/llms-full-txt.ts
+++ b/src/generator/llms-full-txt.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import matter from 'gray-matter'
-import type { LinksExtension, LlmstxtSettings, PreparedFile, VitePressConfig } from '../types'
+import type { LinksExtension, LlmstxtSettings, PreparedFile } from '../types'
 import { generateMetadata } from '../utils'
 
 /**

--- a/src/generator/llms-txt.ts
+++ b/src/generator/llms-txt.ts
@@ -31,8 +31,11 @@ export interface GenerateLLMsTxtOptions {
 	/** The link extension for generated links. */
 	linksExtension?: LinksExtension
 
-	/** Whether to use clean URLs (without the extension). */
-	cleanUrls?: VitePressConfig['cleanUrls']
+	/** Whether to use clean URLs (without the extension). VitePressConfig['cleanUrls'] */
+	cleanUrls?: boolean
+
+	/** The base URL path from VitePress config. VitePressConfig['base'] */
+	base?: string
 
 	/** Optional sidebar configuration for organizing the TOC. */
 	sidebar?: DefaultTheme.Sidebar
@@ -62,6 +65,8 @@ export async function generateLLMsTxt(
 		domain,
 		sidebar,
 		directoryFilter,
+		cleanUrls,
+		base,
 	}: GenerateLLMsTxtOptions,
 ): Promise<string> {
 	// @ts-expect-error
@@ -98,6 +103,8 @@ export async function generateLLMsTxt(
 		domain,
 		sidebarConfig: sidebar || vitepressConfig?.themeConfig?.sidebar,
 		directoryFilter,
+		cleanUrls,
+		base,
 	})
 
 	return expandTemplate(LLMsTxtTemplate, templateVariables)

--- a/src/generator/llms-txt.ts
+++ b/src/generator/llms-txt.ts
@@ -31,11 +31,14 @@ export interface GenerateLLMsTxtOptions {
 	/** The link extension for generated links. */
 	linksExtension?: LinksExtension
 
-	/** Whether to use clean URLs (without the extension). VitePressConfig['cleanUrls'] */
-	cleanUrls?: boolean
+	/** Whether to use clean URLs (without the extension). */
+	cleanUrls?: VitePressConfig['cleanUrls']
 
-	/** The base URL path from VitePress config. VitePressConfig['base'] */
-	base?: string
+	/** The base URL path from VitePress config.
+	 *
+	 * {@link VitePressConfig.base}
+	 */
+	base?: VitePressConfig['base']
 
 	/** Optional sidebar configuration for organizing the TOC. */
 	sidebar?: DefaultTheme.Sidebar

--- a/src/generator/page-generator.ts
+++ b/src/generator/page-generator.ts
@@ -12,12 +12,14 @@ import { generateMetadata } from '../utils/template-utils'
  * @param outDir - The output directory.
  * @param domain - The domain to use for links.
  * @param cleanUrls - Whether to use clean URLs.
+ * @param base - The base URL path from VitePress config.
  */
 export async function generateLLMFriendlyPages(
 	preparedFiles: PreparedFile[],
 	outDir: string,
 	domain?: string,
 	cleanUrls?: boolean,
+	base?: string,
 ): Promise<void> {
 	const tasks = preparedFiles.map(async (file) => {
 		try {
@@ -35,6 +37,7 @@ export async function generateLLMFriendlyPages(
 						filePath: file.path,
 						linksExtension: '.md',
 						cleanUrls,
+						base,
 					}),
 				),
 			)

--- a/src/generator/toc.ts
+++ b/src/generator/toc.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import type { DefaultTheme } from 'vitepress'
-import type { LinksExtension, LlmstxtSettings, PreparedFile, VitePressConfig } from '../types'
+import type { LinksExtension, LlmstxtSettings, PreparedFile } from '../types'
 import { generateLink, stripExtPosix, transformToPosixPath } from '../utils'
 
 /**

--- a/src/generator/toc.ts
+++ b/src/generator/toc.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import type { DefaultTheme } from 'vitepress'
-import type { LinksExtension, LlmstxtSettings, PreparedFile } from '../types'
+import type { LinksExtension, LlmstxtSettings, PreparedFile, VitePressConfig } from '../types'
 import { generateLink, stripExtPosix, transformToPosixPath } from '../utils'
 
 /**
@@ -19,7 +19,7 @@ export const generateTOCLink = (
 	domain: LlmstxtSettings['domain'],
 	relativePath: string,
 	extension?: LinksExtension,
-	cleanUrls: boolean = false,
+	cleanUrls: VitePressConfig['cleanUrls'] = false,
 	base?: string,
 ) => {
 	const description: string = file.file.data.description
@@ -99,7 +99,7 @@ async function processSidebarSection(
 	outDir: string,
 	domain?: LlmstxtSettings['domain'],
 	linksExtension?: LinksExtension,
-	cleanUrls?: boolean,
+	cleanUrls?: VitePressConfig['cleanUrls'],
 	depth = 3,
 	base = '',
 ): Promise<string> {
@@ -222,11 +222,14 @@ export interface GenerateTOCOptions {
 	/** The link extension for generated links. */
 	linksExtension?: LinksExtension
 
-	/** Whether to use clean URLs (without the extension). VitePressConfig['cleanUrls'] */
-	cleanUrls?: boolean
+	/** Whether to use clean URLs (without the extension). */
+	cleanUrls?: VitePressConfig['cleanUrls']
 
-	/** The base URL path from VitePress config. VitePressConfig['base'] */
-	base?: string
+	/** The base URL path from VitePress config.
+	 *
+	 * {@link VitePressConfig.base}
+	 */
+	base?: VitePressConfig['base']
 
 	/**
 	 * Optional directory filter to only include files within the specified directory.

--- a/src/plugin/hooks.ts
+++ b/src/plugin/hooks.ts
@@ -232,8 +232,8 @@ export async function generateBundle(
 						domain: settings.domain,
 						sidebar: resolvedSidebar,
 						linksExtension: !settings.generateLLMFriendlyDocsForEachPage ? '.html' : undefined,
-						cleanUrls: config?.vitepress?.userConfig?.cleanUrls,
-						base: config?.vitepress?.userConfig?.base,
+						cleanUrls: config.vitepress.cleanUrls,
+						base: config.base,
 						directoryFilter,
 					})
 
@@ -283,8 +283,8 @@ export async function generateBundle(
 					const llmsFullTxt = await generateLLMsFullTxt(preparedFiles, {
 						domain: settings.domain,
 						linksExtension: !settings.generateLLMFriendlyDocsForEachPage ? '.html' : undefined,
-						cleanUrls: config?.vitepress?.userConfig?.cleanUrls,
-						base: config?.vitepress?.userConfig?.base,
+						cleanUrls: config.vitepress.cleanUrls,
+						base: config.base,
 						directoryFilter,
 					})
 
@@ -310,8 +310,8 @@ export async function generateBundle(
 				preparedFiles,
 				outDir,
 				settings.domain,
-				config?.vitepress?.userConfig?.cleanUrls,
-				config?.vitepress?.userConfig?.base,
+				config.vitepress.cleanUrls,
+				config.base,
 			),
 		)
 	}

--- a/src/plugin/hooks.ts
+++ b/src/plugin/hooks.ts
@@ -232,7 +232,8 @@ export async function generateBundle(
 						domain: settings.domain,
 						sidebar: resolvedSidebar,
 						linksExtension: !settings.generateLLMFriendlyDocsForEachPage ? '.html' : undefined,
-						cleanUrls: config.cleanUrls,
+						cleanUrls: config?.vitepress?.userConfig?.cleanUrls,
+						base: config?.vitepress?.userConfig?.base,
 						directoryFilter,
 					})
 
@@ -282,7 +283,8 @@ export async function generateBundle(
 					const llmsFullTxt = await generateLLMsFullTxt(preparedFiles, {
 						domain: settings.domain,
 						linksExtension: !settings.generateLLMFriendlyDocsForEachPage ? '.html' : undefined,
-						cleanUrls: config.cleanUrls,
+						cleanUrls: config?.vitepress?.userConfig?.cleanUrls,
+						base: config?.vitepress?.userConfig?.base,
 						directoryFilter,
 					})
 
@@ -303,7 +305,14 @@ export async function generateBundle(
 	}
 
 	if (settings.generateLLMFriendlyDocsForEachPage) {
-		tasks.push(generateLLMFriendlyPages(preparedFiles, outDir, settings.domain, config.cleanUrls))
+		tasks.push(
+			generateLLMFriendlyPages(
+				preparedFiles,
+				outDir,
+				settings.domain,
+				config?.vitepress?.userConfig?.cleanUrls,
+			),
+		)
 	}
 
 	if (tasks.length) {

--- a/src/plugin/hooks.ts
+++ b/src/plugin/hooks.ts
@@ -311,6 +311,7 @@ export async function generateBundle(
 				outDir,
 				settings.domain,
 				config?.vitepress?.userConfig?.cleanUrls,
+				config?.vitepress?.userConfig?.base,
 			),
 		)
 	}

--- a/src/utils/template-utils.ts
+++ b/src/utils/template-utils.ts
@@ -1,5 +1,5 @@
 import type { GrayMatterFile, Input } from 'gray-matter'
-import type { LinksExtension, LlmstxtSettings, VitePressConfig } from '../types'
+import type { LinksExtension, LlmstxtSettings } from '../types'
 import { stripExtPosix, transformToPosixPath } from './file-utils'
 
 /**

--- a/tests/generator/page-generator.test.ts
+++ b/tests/generator/page-generator.test.ts
@@ -16,7 +16,7 @@ describe('generateLLMFriendlyPages', () => {
 	})
 	it('should generate LLM friendly pages for each prepared file', async () => {
 		const preparedFiles = preparedFilesSample.slice(1)
-		await generateLLMFriendlyPages(preparedFiles, outDir, 'https://example.com', false, undefined)
+		await generateLLMFriendlyPages(preparedFiles, outDir, 'https://example.com', false)
 
 		// console.log(writeFile.mock.calls)
 		// console.log(preparedFilesSample)

--- a/tests/generator/page-generator.test.ts
+++ b/tests/generator/page-generator.test.ts
@@ -16,7 +16,7 @@ describe('generateLLMFriendlyPages', () => {
 	})
 	it('should generate LLM friendly pages for each prepared file', async () => {
 		const preparedFiles = preparedFilesSample.slice(1)
-		await generateLLMFriendlyPages(preparedFiles, outDir, 'https://example.com', false)
+		await generateLLMFriendlyPages(preparedFiles, outDir, 'https://example.com', false, undefined)
 
 		// console.log(writeFile.mock.calls)
 		// console.log(preparedFilesSample)

--- a/tests/plugin/index.test.ts
+++ b/tests/plugin/index.test.ts
@@ -198,6 +198,42 @@ describe('llmstxt plugin', () => {
 			expect(writeFile.mock?.lastCall?.[1]).toMatchSnapshot()
 		})
 
+		it('should respect vitepress base option when generating output paths', async () => {
+			const configWithBase = {
+				...mockConfig,
+				base: 'awesomeproject',
+
+				vitepress: {
+					...mockConfig.vitepress,
+				},
+			}
+
+			plugin = llmstxt({ generateLLMsFullTxt: false, generateLLMsTxt: false })
+			// @ts-ignore
+			plugin[1].configResolved(configWithBase)
+			await Promise.all([
+				// @ts-ignore
+				plugin[0].transform(fakeMarkdownDocument, 'docs/test.md'),
+				// @ts-ignore
+				plugin[0].transform(fakeMarkdownDocument, 'docs/guide/index.md'),
+			])
+			// @ts-ignore
+			await plugin[1].generateBundle()
+
+			// Should generate files with correct url frontmatter including base
+			expect(writeFile).toHaveBeenCalledTimes(2)
+			expect(writeFile).nthCalledWith(
+				1,
+				path.resolve(configWithBase.vitepress.outDir, 'test.md'),
+				'---\nurl: /awesomeproject/test.md\n---\n# Some cool stuff\n',
+			)
+			expect(writeFile).nthCalledWith(
+				2,
+				path.resolve(configWithBase.vitepress.outDir, 'guide.md'),
+				'---\nurl: /awesomeproject/guide.md\n---\n# Some cool stuff\n',
+			)
+		})
+
 		describe('rewrites handling', () => {
 			it('should apply simple rewrites to file paths', async () => {
 				const configWithRewrites = {

--- a/tests/utils/utils.test.ts
+++ b/tests/utils/utils.test.ts
@@ -20,33 +20,28 @@ describe('generateLink', () => {
 	})
 
 	it('generates a link with base URL', () => {
-		const result = generateLink('docs/guide', sampleDomain, '.md', false, '/docs/flowdown')
-		expect(result).toBe(`${sampleDomain}/docs/flowdown/docs/guide.md`)
+		const result = generateLink('docs/guide', sampleDomain, '.md', false, '/awesomeproject')
+		expect(result).toBe(`${sampleDomain}/awesomeproject/docs/guide.md`)
 	})
 
 	it('generates a link with base URL without domain', () => {
-		const result = generateLink('docs/guide', undefined, '.md', false, '/docs/flowdown')
-		expect(result).toBe('/docs/flowdown/docs/guide.md')
+		const result = generateLink('docs/guide', undefined, '.md', false, '/awesomeproject')
+		expect(result).toBe('/awesomeproject/docs/guide.md')
 	})
 
 	it('generates a link with base URL and clean URLs', () => {
-		const result = generateLink('docs/guide', sampleDomain, '.md', true, '/docs/flowdown')
-		expect(result).toBe(`${sampleDomain}/docs/flowdown/docs/guide`)
+		const result = generateLink('docs/guide', sampleDomain, '.md', true, '/awesomeproject')
+		expect(result).toBe(`${sampleDomain}/awesomeproject/docs/guide`)
 	})
 
 	it('handles base URL without leading slash', () => {
-		const result = generateLink('docs/guide', sampleDomain, '.md', false, 'docs/flowdown')
-		expect(result).toBe(`${sampleDomain}/docs/flowdown/docs/guide.md`)
+		const result = generateLink('docs/guide', sampleDomain, '.md', false, 'awesomeproject')
+		expect(result).toBe(`${sampleDomain}/awesomeproject/docs/guide.md`)
 	})
 
 	it('handles base URL with trailing slash', () => {
-		const result = generateLink('docs/guide', sampleDomain, '.md', false, '/docs/flowdown/')
-		expect(result).toBe(`${sampleDomain}/docs/flowdown/docs/guide.md`)
-	})
-
-	it('handles path with leading slash', () => {
-		const result = generateLink('/docs/guide', sampleDomain, '.md', false, '/docs/flowdown')
-		expect(result).toBe(`${sampleDomain}/docs/flowdown/docs/guide.md`)
+		const result = generateLink('docs/guide', sampleDomain, '.md', false, '/awesomeproject/')
+		expect(result).toBe(`${sampleDomain}/awesomeproject/docs/guide.md`)
 	})
 })
 

--- a/tests/utils/utils.test.ts
+++ b/tests/utils/utils.test.ts
@@ -18,6 +18,36 @@ describe('generateLink', () => {
 		const result = generateLink('docs/guide', sampleDomain, '.md', true)
 		expect(result).toBe(`${sampleDomain}/docs/guide`)
 	})
+
+	it('generates a link with base URL', () => {
+		const result = generateLink('docs/guide', sampleDomain, '.md', false, '/docs/flowdown')
+		expect(result).toBe(`${sampleDomain}/docs/flowdown/docs/guide.md`)
+	})
+
+	it('generates a link with base URL without domain', () => {
+		const result = generateLink('docs/guide', undefined, '.md', false, '/docs/flowdown')
+		expect(result).toBe('/docs/flowdown/docs/guide.md')
+	})
+
+	it('generates a link with base URL and clean URLs', () => {
+		const result = generateLink('docs/guide', sampleDomain, '.md', true, '/docs/flowdown')
+		expect(result).toBe(`${sampleDomain}/docs/flowdown/docs/guide`)
+	})
+
+	it('handles base URL without leading slash', () => {
+		const result = generateLink('docs/guide', sampleDomain, '.md', false, 'docs/flowdown')
+		expect(result).toBe(`${sampleDomain}/docs/flowdown/docs/guide.md`)
+	})
+
+	it('handles base URL with trailing slash', () => {
+		const result = generateLink('docs/guide', sampleDomain, '.md', false, '/docs/flowdown/')
+		expect(result).toBe(`${sampleDomain}/docs/flowdown/docs/guide.md`)
+	})
+
+	it('handles path with leading slash', () => {
+		const result = generateLink('/docs/guide', sampleDomain, '.md', false, '/docs/flowdown')
+		expect(result).toBe(`${sampleDomain}/docs/flowdown/docs/guide.md`)
+	})
 })
 
 describe('getDirectoriesAtDepths', () => {


### PR DESCRIPTION
Hiii~~ hewwo!! (づ｡◕‿‿◕｡)づ

I noticed a wittle oopsie woopsie! >w< When we twied to put our cute wittle project in a sub-fowdew using the `base` URL in our VitePwess configy-wiggy... aww the paths went **poof** and got wost! ˚‧º·(˚ ˃̣̣̥⌓˂̣̣̥ )‧º·˚

Aww the winky-winkies to our CSS and JS wewe bwoken and sad, and the page wooked so scawy and empty!! It was wike VitePwess-chan wasn't telling our code her secwet `base` addwess! So mean!

BUT DON'T WOWWY!! I did a wittle fixie wixie magic!! ✨ I taught our code to be a good fwiend and wisten to VitePwess-chan! Now it weads the `base` URL and adds a wittle pwefixy-wefixy to evewything, so nothing gets wost evew again! Yay!

Now our appwication can wive happily in any sub-diwectowy you want, and aww the links will be \~sooper-dooper-pewfect\~!! It's all sparkly and shiny now!

Pwease weview my codey-wodey! *nuzzles your review button and wags tail* x3

Maybe closes #34