### PR TITLE
fix: use base path for relative path resolution in TOC generation

### DIFF
--- a/src/generator/toc.ts
+++ b/src/generator/toc.ts
@@ -118,7 +118,8 @@ async function processSidebarSection(
 							(item.base ?? section.base ?? base ?? '') + item.link,
 						)
 						const matchingFile = preparedFiles.find((file) => {
-							const relativePath = `/${transformToPosixPath(stripExtPosix(file.path))}`
+							const basePrefix = base.endsWith('/') ? base : `${base}/`
+							const relativePath = `${basePrefix}${transformToPosixPath(stripExtPosix(file.path))}`
 							return isPathMatch(relativePath, normalizedItemLink)
 						})
 

--- a/tests/generator/__snapshots__/toc.test.ts.snap
+++ b/tests/generator/__snapshots__/toc.test.ts.snap
@@ -63,6 +63,15 @@ exports[`generateTOC resolves paths with common prefixes correctly 1`] = `
 "
 `;
 
+exports[`generateTOC resolves paths with base options 1`] = `
+"### Blog Started
+
+- [First version](/docs/blog/v1.md): Blazing fast frontend tool
+- [New features!](/docs/blog/v1.1.md): Instructions on how to get started with the tool
+
+"
+`;
+
 exports[`generateTOC with directoryFilter should include all files when directoryFilter is "." (root) 1`] = `
 "- [Some cool tool](/index.md): Blazing fast frontend tool
 - [Getting started](/test/getting-started.md): Instructions on how to get started with the tool
@@ -75,15 +84,5 @@ exports[`generateTOC with directoryFilter should filter files by directory when 
 "- [Getting started](/test/getting-started.md): Instructions on how to get started with the tool
 - [Quickstart](/test/quickstart.md): Instructions for quick project initialization
 - [Some other section](/test/other.md)
-"
-`;
-
-exports[`generateTOC resolves paths with common prefixes correctly 2 1`] = `
-"
-"
-`;
-
-exports[`generateTOC resolves paths with base options 1`] = `
-"
 "
 `;

--- a/tests/generator/__snapshots__/toc.test.ts.snap
+++ b/tests/generator/__snapshots__/toc.test.ts.snap
@@ -77,3 +77,13 @@ exports[`generateTOC with directoryFilter should filter files by directory when 
 - [Some other section](/test/other.md)
 "
 `;
+
+exports[`generateTOC resolves paths with common prefixes correctly 2 1`] = `
+"
+"
+`;
+
+exports[`generateTOC resolves paths with base options 1`] = `
+"
+"
+`;

--- a/tests/generator/toc.test.ts
+++ b/tests/generator/toc.test.ts
@@ -167,6 +167,16 @@ describe('generateTOC', () => {
 
 		expect(toc).toMatchSnapshot()
 	})
+
+	it('resolves paths with base options', async () => {
+		const toc = await generateTOC(preparedFilesWithCommonPrefixSample, {
+			outDir,
+			base: '/docs',
+			sidebarConfig: sampleObjectVitePressSidebarWithCommonPrefix,
+		})
+
+		expect(toc).toMatchSnapshot()
+	})
 })
 
 describe('generateTOCLink', () => {


### PR DESCRIPTION
### Description

This PR fixes the TOC (Table of Contents) generation logic to properly handle base paths when resolving file paths against sidebar items.

Previously, the code was hardcoding a / prefix without considering the base configuration option, which caused incorrect path matching when VitePress sites are deployed with a base path (e.g., /docs/).

### Before

With base: '/docs/', TOC items failed to match sidebar entries. For example, sidebar data could not be retrieved at all. (See commit 47410cf)

### After

With this fix (commit 2d8a290), TOC items are now correctly resolved against sidebar entries even when base is set. A test case has been added to cover this scenario.
