### PR TITLE
fix: removing duplicate next() calls in dev-server

### DIFF
--- a/src/plugin/dev-server.ts
+++ b/src/plugin/dev-server.ts
@@ -21,9 +21,7 @@ export async function configureDevServer(server: ViteDevServer, config: VitePres
 				res.end(content)
 				return
 			} catch (_error) {
-				// If file doesn't exist or can't be read, continue to next middleware
 				log.warn(`Failed to return ${pc.cyan(req.url)}: File not found`)
-				next()
 			}
 		}
 


### PR DESCRIPTION
### Description

On the development server, a duplicate next() call occurred when an error crashed the server. Since there was a next() without return in the `catch`, I removed it so that, in case of an error, the log would be displayed and the final rule would be executed.

### Related Issue

No response