### PR TITLE
refactor: update copy button color on hover

### DIFF
--- a/src/vitepress-components/CopyOrDownloadAsMarkdownButtons.vue
+++ b/src/vitepress-components/CopyOrDownloadAsMarkdownButtons.vue
@@ -85,7 +85,7 @@ function downloadMarkdown() {
 	transition: background 0.2s, border 0.2s;
 }
 .markdown-copy-buttons button:hover {
-	color: white;
+	color: var(--vp-c-neutral);
 }
 .markdown-copy-buttons img {
 	vertical-align: middle;


### PR DESCRIPTION
### Description

The hover color wasn't using a color from the [default theme variables](https://github.com/vuejs/vitepress/blob/main/src/client/theme-default/styles/vars.css) and was causing the buttons to effectively disappear when in light mode.

https://github.com/user-attachments/assets/907efb27-7bf0-431c-9469-b1bba16c5a16

Alternatively, I was wondering whether you've considered using the `brand` theme colors so the buttons match similar elements like the edit link at the bottom of the page.

<img width="664" height="174" alt="Screenshot 2025-11-09 at 1 26 32 PM" src="https://github.com/user-attachments/assets/ca82f85f-2ba4-4d89-9771-4066f159465e" />
