### PR TITLE
fix: resolve build failure when generateLLMFriendlyDocsForEachPage is false

### DIFF
--- a/src/plugin/hooks.ts
+++ b/src/plugin/hooks.ts
@@ -127,6 +127,10 @@ export async function transform(
 					content.slice(0, idx + marker.length) + hintBlock + content.slice(idx + marker.length)
 			}
 			modifiedContent = matter.stringify(content, modifiedContent.data)
+		} else {
+			// Ensure modifiedContent is converted back to string when no hint is generated,
+			// otherwise GrayMatterFile object causes src.replace is not a function
+			modifiedContent = matter.stringify(modifiedContent.content, modifiedContent.data)
 		}
 	}
 


### PR DESCRIPTION
## Problem

When `generateLLMFriendlyDocsForEachPage` is set to `false`, the build fails with:

```
src.replace is not a function
```

Reported in #120.

## Root Cause

In the `transform` function (`src/plugin/hooks.ts`), when `injectLLMHint` is enabled, the content is parsed into a `GrayMatterFile` object via `matter(modifiedContent)` (line 87).

When `generateLLMFriendlyDocsForEachPage` is `false` and the page is not the main page, no `llmHint` is generated. The existing code only calls `matter.stringify()` inside the `if (llmHint)` block, so when no hint is generated, `modifiedContent` remains a `GrayMatterFile` object instead of being converted back to a string.

This object is then returned as `{ code: modifiedContent }`, but VitePress expects `code` to be a string and calls `src.replace()` on it, which fails.

## Fix

Added an `else` branch to the `if (llmHint)` block that converts `modifiedContent` back to a string via `matter.stringify()` even when no hint is generated.

### Changes

- `src/plugin/hooks.ts`: Added else branch to stringify GrayMatterFile when no LLM hint is generated

Fixes #120