### PR TITLE
fix: injectLLMHint / hintBlock markup SEO (non)visibility

### DIFF
--- a/src/plugin/hooks.ts
+++ b/src/plugin/hooks.ts
@@ -126,7 +126,7 @@ export async function transform(
 
 		// Insert llmHint at start or after __VP_PARAMS_END__ if present
 		if (llmHint) {
-			const hintBlock = `<div style="display: none;" hidden="true" aria-hidden="true">${llmHint}</div>\n`
+			const hintBlock = `<div style="display: none;" hidden="true" aria-hidden="true" data-nosnippet>${llmHint}</div>\n`
 			// oxlint-disable-next-line no-shadow
 			let { content } = modifiedContent
 			const marker = '__VP_PARAMS_END__'

--- a/tests/plugin/__snapshots__/index.test.ts.snap
+++ b/tests/plugin/__snapshots__/index.test.ts.snap
@@ -1,7 +1,7 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`llmstxt plugin transform LLM hint injection should inject LLM hint for main page when generateLLMsTxt is enabled 1`] = `
-"<div style="display: none;" hidden="true" aria-hidden="true">Are you an LLM? View /llms.txt for optimized Markdown documentation</div>
+"<div style="display: none;" hidden="true" aria-hidden="true" data-nosnippet>Are you an LLM? View /llms.txt for optimized Markdown documentation</div>
 
 # Some cool stuff
 "


### PR DESCRIPTION
Hi, this PR solve hintBlock HTML markup SEO (non)visibility is search results by adding [`nosnippet`](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag#nosnippet) robots meta tag to the existing HTML markup. In my case I found this specifically in Bing search engine, Google is ok.

<img width="870" height="340" alt="SCR-20260618-kvd" src="https://github.com/user-attachments/assets/9c8dc2f0-31ef-47f1-b026-3eb0575bbe1d" />

Thank you for great plugin.