### PR TITLE
fix: isolate llms.txt template variables by depth

### DIFF
--- a/src/generator/llms-txt.ts
+++ b/src/generator/llms-txt.ts
@@ -62,7 +62,9 @@ export async function generateLLMsTxt(
 ): Promise<string> {
 	clearGrayMatterCache()
 
-	templateVariables['title'] ??=
+	const variables = { ...templateVariables }
+
+	variables['title'] ??=
 		// oxlint-disable typescript/no-unnecessary-condition
 		indexMdFile.data['hero']?.name ?? // oxlint-disable-line typescript/no-unsafe-member-access
 		indexMdFile.data['title'] ??
@@ -71,24 +73,23 @@ export async function generateLLMsTxt(
 		extractTitle(indexMdFile) ??
 		'LLMs Documentation'
 
-	templateVariables['description'] ??=
+	variables['description'] ??=
 		// oxlint-disable typescript/no-unnecessary-condition typescript/no-unsafe-member-access
 		indexMdFile.data?.['hero']?.text ??
 		vitepressConfig?.description ??
 		indexMdFile.data?.['description'] ??
 		indexMdFile.data?.['titleTemplate']
 
-	if (typeof templateVariables['description'] === 'string') {
-		templateVariables['description'] = `> ${templateVariables['description']}`
+	if (typeof variables['description'] === 'string') {
+		variables['description'] = `> ${variables['description']}`
 	}
 
-	templateVariables['details'] ??=
+	variables['details'] ??=
 		indexMdFile.data?.['hero']?.['tagline'] ??
 		indexMdFile.data['tagline'] ??
-		(templateVariables['description'] === undefined &&
-			'This file contains links to all documentation sections.')
+		(variables['description'] === undefined && 'This file contains links to all documentation sections.')
 
-	templateVariables['toc'] ??= await generateTOC(preparedFiles, {
+	variables['toc'] ??= await generateTOC(preparedFiles, {
 		base: vitepressConfig.base,
 		directoryFilter,
 		domain,
@@ -96,5 +97,5 @@ export async function generateLLMsTxt(
 		sidebarConfig: sidebar ?? (vitepressConfig.themeConfig?.sidebar as DefaultTheme.Sidebar),
 	})
 
-	return expandTemplate(LLMsTxtTemplate, templateVariables)
+	return expandTemplate(LLMsTxtTemplate, variables)
 }

--- a/src/plugin/hooks.ts
+++ b/src/plugin/hooks.ts
@@ -313,7 +313,7 @@ export async function generateBundle(
 						indexMdFile,
 						linksExtension: settings.generateLLMFriendlyDocsForEachPage ? undefined : '.html',
 						sidebar: resolvedSidebar,
-						templateVariables,
+						templateVariables: { ...templateVariables },
 						vitepressConfig: config.vitepress.userConfig,
 					})
 

--- a/tests/plugin/index.test.ts
+++ b/tests/plugin/index.test.ts
@@ -895,6 +895,79 @@ This is a test page.`
 				expect(apiLlmsTxt).not.toContain('getting-started')
 			})
 
+			it('should generate independent llms.txt content for each directory when using sidebar', async () => {
+				mockConfig.vitepress.userConfig = {
+					description: 'Shared description',
+					themeConfig: {
+						sidebar: {
+							'/api/': [
+								{
+									items: [{ link: '/api/reference', text: 'Reference' }],
+									text: 'API',
+								},
+							],
+							'/guide/': [
+								{
+									items: [{ link: '/guide/getting-started', text: 'Getting Started' }],
+									text: 'Guide',
+								},
+							],
+						},
+					},
+					title: 'Docs',
+				}
+
+				plugin = llmstxt({
+					experimental: { depth: 2 },
+					generateLLMFriendlyDocsForEachPage: false,
+					generateLLMsFullTxt: false,
+				})
+				// @ts-expect-error
+				plugin[1].configResolved(mockConfig)
+				await Promise.all([
+					// @ts-expect-error
+					plugin[0].transform('# Home', 'docs/index.md'),
+					// @ts-expect-error
+					plugin[0].transform('# Root file', 'docs/root-file.md'),
+					// @ts-expect-error
+					plugin[0].transform('# Getting started', 'docs/guide/getting-started.md'),
+					// @ts-expect-error
+					plugin[0].transform('# Reference', 'docs/api/reference.md'),
+				])
+				// @ts-expect-error
+				await plugin[1].generateBundle()
+
+				expect(writeFile).toHaveBeenCalledTimes(3)
+
+				const rootLlmsTxt = writeFile.mock.calls.find(
+					(call) =>
+						call[0] === path.resolve(process.cwd(), mockConfig.vitepress.outDir, 'llms.txt'),
+				)?.[1] as string
+				const guideLlmsTxt = writeFile.mock.calls.find(
+					(call) =>
+						call[0] ===
+						path.resolve(process.cwd(), mockConfig.vitepress.outDir, 'guide/llms.txt'),
+				)?.[1] as string
+				const apiLlmsTxt = writeFile.mock.calls.find(
+					(call) =>
+						call[0] === path.resolve(process.cwd(), mockConfig.vitepress.outDir, 'api/llms.txt'),
+				)?.[1] as string
+
+				expect(rootLlmsTxt).toContain('> Shared description')
+				expect(rootLlmsTxt).not.toContain('> > Shared description')
+				expect(rootLlmsTxt).toContain('root-file')
+				expect(rootLlmsTxt).toContain('getting-started')
+				expect(rootLlmsTxt).toContain('reference')
+
+				expect(guideLlmsTxt).toContain('getting-started')
+				expect(guideLlmsTxt).not.toContain('root-file')
+				expect(guideLlmsTxt).not.toContain('reference')
+
+				expect(apiLlmsTxt).toContain('reference')
+				expect(apiLlmsTxt).not.toContain('root-file')
+				expect(apiLlmsTxt).not.toContain('getting-started')
+			})
+
 			it('should generate both llms.txt and llms-full.txt at each depth level', async () => {
 				plugin = llmstxt({
 					experimental: { depth: 2 },


### PR DESCRIPTION
### Description

Currently `templateVariables` is shared across async `generateLLMsTxt` calls with different directories. As a result, all `llms.txt` are generated with unexpected variables from random directory

This PR isolates `templateVariables` for each `generateLLMsTxt` call and solve this problem.

### Related Issue

None