### PR TITLE
docs: suggest validating the deployed llms.txt in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,18 @@ Check out the Plugins API Guide for documentation about creating plugins.
 <llm-exclude>Note only for humans</llm-exclude>
 ```
 
+## 🔍 Validating the deployed output
+
+This plugin generates a correct `llms.txt` at build time, but serving-layer config can break it in production: host redirect rules, domain migrations, and docs restructures all bite after the build goes green.
+
+[llms-txt-check](https://github.com/portdeveloper/llms-txt-check) verifies the deployed file against what your site actually serves (it resolves this plugin's relative URLs against your site's origin automatically):
+
+```yaml
+- run: npx llms-txt-check https://your-docs-site.com
+```
+
+It exits nonzero when the file or any listed URL stops serving, so the deploy that breaks a route goes red.
+
 ## 🚀 Why `vitepress-plugin-llms`?
 
 LLMs (Large Language Models) are great at processing text, but traditional documentation formats can be too heavy and cluttered. `vitepress-plugin-llms` generates raw Markdown documentation that LLMs can efficiently process


### PR DESCRIPTION
hey! i built a checker that validates deployed llms.txt files against what the site actually serves, and while testing it against vuejs.org and vite.dev (both use this plugin) i made sure it handles your relative-URL output correctly, it resolves them against the origin and fetches each one. both sites pass btw. the failures i've found on other frameworks' sites were all serving-layer breakage after a green build (drizzle-team/drizzle-orm-docs#705 is 71 dead links, trpc/trpc#7462 is 19). this PR adds a short README section pointing users at a CI check. happy to reword or trim!